### PR TITLE
Link Sunil Abraham references in publication lead sections

### DIFF
--- a/publications/authors.md
+++ b/publications/authors.md
@@ -9,7 +9,7 @@ created: 2025-11-09
 This directory highlights authors who have collaborated with **Sunil Abraham** on various publications featured within this project.  
 - Each author listed below has contributed to one or more works — as co-author, collaborator, or editor.  
 - Please note that this directory represents collaborations and not the authors’ complete body of work.  
-- You can select a name below to view their shared works with Sunil Abraham.
+- You can select a name below to view their shared works with [Sunil Abraham](/sunil/).
 
 <div class="authors-directory">
 

--- a/publications/availability-accessibility-government-information.md
+++ b/publications/availability-accessibility-government-information.md
@@ -11,7 +11,7 @@ pdf: /publications/files/availability-accessibility-government-information.pdf
 created: 2025-11-11
 ---
 
-**Availability and Accessibility of Government Information in the Public Domain** is a policy brief authored by Sunil Abraham**, Nirmita Narasimhan, Beliappa, and Anandhi Vishwanath, with inputs from Dipendra Manocha, Saksham, and Deepak Maheshwari (Symantec).  
+**Availability and Accessibility of Government Information in the Public Domain** is a policy brief authored by [Sunil Abraham](/sunil/)**, Nirmita Narasimhan, Beliappa, and Anandhi Vishwanath, with inputs from Dipendra Manocha, Saksham, and Deepak Maheshwari (Symantec).  
 
 The brief highlights the continuing lack of accessible and authentic government information on official websites in India. It explains how common publishing practices lead to non-searchable, non-accessible, and legally weak documents — and offers a clear digital-first workflow to ensure that government information is authentic, searchable, indexable, and accessible to all citizens.
 

--- a/publications/does-the-government-want-to-enter-our-homes.md
+++ b/publications/does-the-government-want-to-enter-our-homes.md
@@ -10,7 +10,7 @@ permalink: /publications/does-the-government-want-to-enter-our-homes/
 created: 2025-11-23
 ---
 
-**Does the Government Want to Enter Our Homes?** is a commentary by Sunil Abraham, published in *Pune Mirror* on 10 August 2010. The article discusses the government's attempt to gain access to encrypted BlackBerry-to-BlackBerry communications, the broader implications for journalists, whistle-blowers, civil liberties, and the critical need for safeguards such as judicial oversight and transparency.
+**Does the Government Want to Enter Our Homes?** is a commentary by [Sunil Abraham](/sunil/), published in *Pune Mirror* on 10 August 2010. The article discusses the government's attempt to gain access to encrypted BlackBerry-to-BlackBerry communications, the broader implications for journalists, whistle-blowers, civil liberties, and the critical need for safeguards such as judicial oversight and transparency.
 
 ## Contents
 

--- a/publications/dont-slapp-free-speech.md
+++ b/publications/dont-slapp-free-speech.md
@@ -12,7 +12,7 @@ permalink: /publications/dont-slapp-free-speech/
 created: 2025-11-23
 ---
 
-**Don't SLAPP Free Speech** is a commentary by Sunil Abraham, with inputs from Snehashish Ghosh, published in *Tehelka Magazine*, Volume 10, Issue 9, on 3 February 2013. The article analyses the blocking of web pages critical of IIPM, strategic litigation against public participation, and the implications of interim injunctions and defamation law for online expression in India.
+**Don't SLAPP Free Speech** is a commentary by [Sunil Abraham](/sunil/), with inputs from Snehashish Ghosh, published in *Tehelka Magazine*, Volume 10, Issue 9, on 3 February 2013. The article analyses the blocking of web pages critical of IIPM, strategic litigation against public participation, and the implications of interim injunctions and defamation law for online expression in India.
 
 ## Contents
 

--- a/publications/facebooks-fall-from-grace-arab-spring-to-indian-winter.md
+++ b/publications/facebooks-fall-from-grace-arab-spring-to-indian-winter.md
@@ -10,7 +10,7 @@ permalink: /publications/facebooks-fall-from-grace-arab-spring-to-indian-winter/
 created: 2025-11-11
 ---
 
-**Facebook's Fall From Grace: Arab Spring To Indian Winter** is an opinion column by Sunil Abraham, first published in *Firstpost* on 9 February 2016.  
+**Facebook's Fall From Grace: Arab Spring To Indian Winter** is an opinion column by [Sunil Abraham](/sunil/), first published in *Firstpost* on 9 February 2016.  
 
 The article discusses Facebook's *Free Basics* controversy in India, the Telecom Regulatory Authority of India's (TRAI) landmark regulation prohibiting discriminatory tariffs for data services, and the wider implications for global net neutrality. Sunil Abraham outlines how India's regulatory response set a precedent for fair, open, and citizen-centric Internet governance.
 

--- a/publications/fixing-aadhaar-security-developers-task-is-to-trim-chances-of-data-breach.md
+++ b/publications/fixing-aadhaar-security-developers-task-is-to-trim-chances-of-data-breach.md
@@ -10,7 +10,7 @@ permalink: /publications/fixing-aadhaar-security-developers-task-is-to-trim-chan
 created: 2025-11-06
 ---
 
-**Fixing Aadhaar: Security developers' task is to trim chances of data breach** is an opinion piece by Sunil Abraham, originally published in *Business Standard* on 10 January 2018.  
+**Fixing Aadhaar: Security developers' task is to trim chances of data breach** is an opinion piece by [Sunil Abraham](/sunil/), originally published in *Business Standard* on 10 January 2018.  
 The column analyses the fragility of centralised identity systems like Aadhaar and argues for systemic design changes such as tokenisation and multi-identifier frameworks to eliminate the possibility of large-scale breaches.
 
 ## Contents

--- a/publications/free-basics-negating-net-parity.md
+++ b/publications/free-basics-negating-net-parity.md
@@ -10,7 +10,7 @@ permalink: /publications/free-basics-negating-net-parity/
 created: 2025-11-14
 ---
 
-**Free Basics: Negating Net Parity** is an article by Sunil Abraham, published in *Deccan Herald* on 2 January 2016. The piece critiques Facebook's Free Basics platform, arguing that it undermines net neutrality, distorts market access, and risks fragmenting the internet into walled gardens.
+**Free Basics: Negating Net Parity** is an article by [Sunil Abraham](/sunil/), published in *Deccan Herald* on 2 January 2016. The piece critiques Facebook's Free Basics platform, arguing that it undermines net neutrality, distorts market access, and risks fragmenting the internet into walled gardens.
 
 ## Contents
 

--- a/publications/freedom-from-monitoring-india-inc-should-push-for-privacy-laws.md
+++ b/publications/freedom-from-monitoring-india-inc-should-push-for-privacy-laws.md
@@ -10,7 +10,7 @@ permalink: /publications/freedom-from-monitoring-india-inc-should-push-for-priva
 created: 2025-11-12
 ---
 
-**Freedom from Monitoring: India Inc Should Push For Privacy Laws** is an opinion article by Sunil Abraham, published in *Forbes India* on 21 August 2013. The piece argues that blanket surveillance weakens security and that Indian industry should support a modern, horizontal privacy law to protect enterprise and citizen interests.
+**Freedom from Monitoring: India Inc Should Push For Privacy Laws** is an opinion article by [Sunil Abraham](/sunil/), published in *Forbes India* on 21 August 2013. The piece argues that blanket surveillance weakens security and that Indian industry should support a modern, horizontal privacy law to protect enterprise and citizen interests.
 
 ## Contents
 

--- a/publications/intermediary-liability-law-needs-updating.md
+++ b/publications/intermediary-liability-law-needs-updating.md
@@ -10,7 +10,7 @@ permalink: /publications/intermediary-liability-law-needs-updating/
 created: 2025-11-11
 ---
 
-**Intermediary Liability Law Needs Updating** is an opinion article by Sunil Abraham, published in *Business Standard* on 9 February 2019. Sunil argues that India must modernise its intermediary liability laws (Section 79 of the IT Act) to increase transparency and accountability, without infringing free expression or constitutional safeguards.
+**Intermediary Liability Law Needs Updating** is an opinion article by [Sunil Abraham](/sunil/), published in *Business Standard* on 9 February 2019. Sunil argues that India must modernise its intermediary liability laws (Section 79 of the IT Act) to increase transparency and accountability, without infringing free expression or constitutional safeguards.
 
 ## Contents
 

--- a/publications/internet-censorship-will-continue-in-opaque-fashion.md
+++ b/publications/internet-censorship-will-continue-in-opaque-fashion.md
@@ -10,7 +10,7 @@ permalink: /publications/internet-censorship-will-continue-in-opaque-fashion/
 created: 2025-11-13
 ---
 
-**Internet Censorship Will Continue in Opaque Fashion** is an article by Sunil Abraham, published in *The Times of India* on 25 March 2015.  
+**Internet Censorship Will Continue in Opaque Fashion** is an article by [Sunil Abraham](/sunil/), published in *The Times of India* on 25 March 2015.  
 The article analyses the Supreme Court’s rulings on Sections 66A, 79, and 69A of the Information Technology Act, explaining that although the verdict upholds free speech online, India’s mechanisms for blocking and censorship remain secretive and non-transparent.
 
 ## Contents

--- a/publications/is-aadhaar-a-breach-of-privacy-hindu.md
+++ b/publications/is-aadhaar-a-breach-of-privacy-hindu.md
@@ -10,7 +10,7 @@ permalink: /publications/is-aadhaar-a-breach-of-privacy-hindu/
 created: 2026-01-14
 ---
 
-**Is Aadhaar a Breach of Privacy?** is an excerpt from a multi-author *The Hindu* op-ed published on 31 March 2017. This version reproduces only Sunil Abraham’s contribution, which argues that Aadhaar functions as mass surveillance infrastructure and proposes technical changes to reduce its privacy and security risks. The full article also includes responses by R.S. Sharma and Baijayant Jay Panda and is available on *The Hindu*’s website.
+**Is Aadhaar a Breach of Privacy?** is an excerpt from a multi-author *The Hindu* op-ed published on 31 March 2017. This version reproduces only [Sunil Abraham](/sunil/)’s contribution, which argues that Aadhaar functions as mass surveillance infrastructure and proposes technical changes to reduce its privacy and security risks. The full article also includes responses by R.S. Sharma and Baijayant Jay Panda and is available on *The Hindu*’s website.
 
 ## Contents
 

--- a/publications/its-the-technology-stupid.md
+++ b/publications/its-the-technology-stupid.md
@@ -10,7 +10,7 @@ permalink: /publications/its-the-technology-stupid/
 created: 2025-11-15
 ---
 
-**It's the Technology, Stupid** is an article by Sunil Abraham, published in *The Hindu BusinessLine* on 31 March 2017. The article appears with the subheading "11 reasons why Aadhaar is not just non-smart but also insecure", outlining structural flaws in Aadhaar's biometric design and explaining why biometrics are unsuitable for secure, citizen-centric e-governance systems.
+**It's the Technology, Stupid** is an article by [Sunil Abraham](/sunil/), published in *The Hindu BusinessLine* on 31 March 2017. The article appears with the subheading "11 reasons why Aadhaar is not just non-smart but also insecure", outlining structural flaws in Aadhaar's biometric design and explaining why biometrics are unsuitable for secure, citizen-centric e-governance systems.
 
 ## Contents
 

--- a/publications/lining-up-the-data-on-the-srikrishna-privacy-draft-bill.md
+++ b/publications/lining-up-the-data-on-the-srikrishna-privacy-draft-bill.md
@@ -10,7 +10,7 @@ permalink: /publications/lining-up-the-data-on-the-srikrishna-privacy-draft-bill
 created: 2025-11-15
 ---
 
-**Lining Up the Data on the Srikrishna Privacy Draft Bill** is an article by Sunil Abraham, published in *The Economic Times* on 30 July 2018. This article discusses the definitions of consent, necessity, proportionality and state exemptions in the Srikrishna Committee's draft data protection bill.
+**Lining Up the Data on the Srikrishna Privacy Draft Bill** is an article by [Sunil Abraham](/sunil/), published in *The Economic Times* on 30 July 2018. This article discusses the definitions of consent, necessity, proportionality and state exemptions in the Srikrishna Committee's draft data protection bill.
 
 ## Contents
 

--- a/publications/media.md
+++ b/publications/media.md
@@ -7,7 +7,7 @@ created: 2025-11-13
 ---
 
 This directory groups **media articles and commentaries** by **Sunil Abraham** according to the **newspaper or media outlet** where they appeared.  
-- Each outlet below includes articles authored or co-authored by Sunil Abraham.  
+- Each outlet below includes articles authored or co-authored by [Sunil Abraham](/sunil/).  
 - Only works categorised under [Media Articles and Commentaries](/categories/media-articles/) are included.  
 - Select an outlet from the list below to view his published articles in that publication.
 

--- a/publications/multiple-aspects-need-to-be-addressed-network-neutrality.md
+++ b/publications/multiple-aspects-need-to-be-addressed-network-neutrality.md
@@ -10,7 +10,7 @@ permalink: /publications/multiple-aspects-need-to-be-addressed-network-neutralit
 created: 2025-11-13
 ---
 
-**Multiple Aspects Need to Be Addressed as the Clamour Grows for Network Neutrality** is an article by Sunil Abraham, published in *DNA India* on 16 April 2015. The piece explains the key forms of network neutrality violations, their social and economic harms, and how India can develop fair regulatory principles to safeguard competition, innovation, and user choice.
+**Multiple Aspects Need to Be Addressed as the Clamour Grows for Network Neutrality** is an article by [Sunil Abraham](/sunil/), published in *DNA India* on 16 April 2015. The piece explains the key forms of network neutrality violations, their social and economic harms, and how India can develop fair regulatory principles to safeguard competition, innovation, and user choice.
 
 ## Contents
 

--- a/publications/net-freedom-campaign-loses-its-way.md
+++ b/publications/net-freedom-campaign-loses-its-way.md
@@ -10,7 +10,7 @@ permalink: /publications/net-freedom-campaign-loses-its-way/
 created: 2025-11-12
 ---
 
-**Net Freedom Campaign Loses Its Way** is an article by Sunil Abraham, published in *The Hindu Business Line* on 10 May 2014. The piece critiques the outcomes of the global NetMundial conference, arguing that despite its participatory promise, the event fell short on protecting digital rights, curbing surveillance, and upholding principles of open and democratic Internet governance.
+**Net Freedom Campaign Loses Its Way** is an article by [Sunil Abraham](/sunil/), published in *The Hindu Business Line* on 10 May 2014. The piece critiques the outcomes of the global NetMundial conference, arguing that despite its participatory promise, the event fell short on protecting digital rights, curbing surveillance, and upholding principles of open and democratic Internet governance.
 
 ## Contents
 

--- a/publications/niti-aayog-discussion-paper-ai-policy.md
+++ b/publications/niti-aayog-discussion-paper-ai-policy.md
@@ -11,7 +11,7 @@ pdf: /publications/files/niti-aayog-discussion-paper-ai-policy.pdf
 created: 2025-11-11
 ---
 
-**NITI Aayog Discussion Paper: An Aspirational Step towards India's AI Policy** is a policy commentary authored by Sunil Abraham, Elonnai Hickok, Amber Sinha, Swaraj Barooah, Shweta Mohandas, Pranav M. Bidare, Swagam Dasgupta, Vishnu Ramachandran, and Senthil Kumar at the Centre for Internet and Society (CIS).  
+**NITI Aayog Discussion Paper: An Aspirational Step towards India's AI Policy** is a policy commentary authored by [Sunil Abraham](/sunil/), Elonnai Hickok, Amber Sinha, Swaraj Barooah, Shweta Mohandas, Pranav M. Bidare, Swagam Dasgupta, Vishnu Ramachandran, and Senthil Kumar at the Centre for Internet and Society (CIS).  
 
 The brief analyses NITI Aayog's 2018 discussion paper on India's National Strategy for Artificial Intelligence, assessing its ambitions, policy directions, and critical omissions. It commends the initiative as a significant step toward a national AI strategy while identifying areas where the paper falls short — particularly on issues of privacy, ethics, fairness, accessibility, and accountability.
 

--- a/publications/privacy-worries-cloud-facebooks-whatsapp-deal.md
+++ b/publications/privacy-worries-cloud-facebooks-whatsapp-deal.md
@@ -10,7 +10,7 @@ permalink: /publications/privacy-worries-cloud-facebooks-whatsapp-deal/
 created: 2025-11-12
 ---
 
-**Privacy Worries Cloud Facebook's WhatsApp Deal** is an article by Sunil Abraham, published in *The Economic Times* on 14 March 2014. The piece examines global and Indian responses to Facebook’s acquisition of WhatsApp, highlighting the absence of comprehensive data protection in India and warning that users' privacy will remain vulnerable until national regulation and enforcement mechanisms are in place.
+**Privacy Worries Cloud Facebook's WhatsApp Deal** is an article by [Sunil Abraham](/sunil/), published in *The Economic Times* on 14 March 2014. The piece examines global and Indian responses to Facebook’s acquisition of WhatsApp, highlighting the absence of comprehensive data protection in India and warning that users' privacy will remain vulnerable until national regulation and enforcement mechanisms are in place.
 
 ## Contents
 

--- a/publications/regulating-the-internet-india-ietf.md
+++ b/publications/regulating-the-internet-india-ietf.md
@@ -11,7 +11,7 @@ pdf: /publications/files/regulating-the-internet-india-ietf.pdf
 created: 2025-11-09
 ---
 
-**Regulating the Internet: The Government of India and Standards Development at the IETF** is a detailed policy brief authored by Aayush Rathi, Gurshabad Grover, and Sunil Abraham, published by the Centre for Internet and Society (CIS), India, in November 2018 (updated December 2018).  
+**Regulating the Internet: The Government of India and Standards Development at the IETF** is a detailed policy brief authored by Aayush Rathi, Gurshabad Grover, and [Sunil Abraham](/sunil/), published by the Centre for Internet and Society (CIS), India, in November 2018 (updated December 2018).  
 
 The report investigates how technical standards bodies such as the Internet Engineering Task Force (IETF) operate as regulatory regimes shaping the Internet, and analyses the Indian government’s limited participation in these critical spaces. Using the global debate around Transport Layer Security (TLS) 1.3 as a case study, it examines the intersection between technological design, public policy, and national security.
 

--- a/publications/save-internet-from-corporate-censorship.md
+++ b/publications/save-internet-from-corporate-censorship.md
@@ -10,7 +10,7 @@ permalink: /publications/save-internet-from-corporate-censorship/
 created: 2026-01-05
 ---
 
-**Save the Internet From Corporate Censorship** is an opinion column by Sunil Abraham, published in *Deccan Chronicle* on 5 September 2018. The article critiques the regime of private censorship exercised by social media companies, particularly in the wake of coordinated bans against Alex Jones and Infowars. It argues for implementing principles of natural justice in content moderation, strengthening competition law, and empowering civil society to hold internet giants accountable.
+**Save the Internet From Corporate Censorship** is an opinion column by [Sunil Abraham](/sunil/), published in *Deccan Chronicle* on 5 September 2018. The article critiques the regime of private censorship exercised by social media companies, particularly in the wake of coordinated bans against Alex Jones and Infowars. It argues for implementing principles of natural justice in content moderation, strengthening competition law, and empowering civil society to hold internet giants accountable.
 
 ## Contents
 

--- a/publications/spreading-unhappiness-equally-around.md
+++ b/publications/spreading-unhappiness-equally-around.md
@@ -10,7 +10,7 @@ permalink: /publications/spreading-unhappiness-equally-around/
 created: 2025-11-15
 ---
 
-**Spreading Unhappiness Equally Around** is an opinion article by Sunil Abraham, published in *Business Standard* on 31 July 2018. This column reviews reactions to the B. N. Srikrishna committee’s draft Personal Data Protection Bill, highlighting where civil society, industry and rights groups remain dissatisfied.
+**Spreading Unhappiness Equally Around** is an opinion article by [Sunil Abraham](/sunil/), published in *Business Standard* on 31 July 2018. This column reviews reactions to the B. N. Srikrishna committee’s draft Personal Data Protection Bill, highlighting where civil society, industry and rights groups remain dissatisfied.
 
 ## Contents
 

--- a/publications/surveillance-project-frontline.md
+++ b/publications/surveillance-project-frontline.md
@@ -10,7 +10,7 @@ permalink: /publications/surveillance-project-frontline/
 created: 2026-01-22
 ---
 
-**Surveillance Project** is a *Frontline* cover story published on 30 March 2016 by Sunil Abraham. Written two weeks after Parliament passed the Aadhaar Act, the article provides a systematic technical and political critique of biometric centralisation, and argues that architectural choices, rather than legal safeguards alone, play a decisive role in shaping whether identification systems enable governance or surveillance.
+**Surveillance Project** is a *Frontline* cover story published on 30 March 2016 by [Sunil Abraham](/sunil/). Written two weeks after Parliament passed the Aadhaar Act, the article provides a systematic technical and political critique of biometric centralisation, and argues that architectural choices, rather than legal safeguards alone, play a decisive role in shaping whether identification systems enable governance or surveillance.
 
 This article was also published as a [chapter](/publications/surveillance-project/) in *Dissent on Aadhaar: Big Data Meets Big Brother*, edited by Reetika Khera (Orient Blackswan, 2018).
 

--- a/publications/surveillance-project.md
+++ b/publications/surveillance-project.md
@@ -14,7 +14,7 @@ pdf: /publications/files/surveillance-project.pdf
 created: 2025-11-06
 ---
 
-**Surveillance Project** is a book chapter by Sunil Abraham, published in *Dissent on Aadhaar: Big Data Meets Big Brother*, edited by Reetika Khera and published by Orient Blackswan in 2018. The chapter critically analyses the Aadhaar programme, arguing that its technological and legal architecture turns a welfare initiative into a mass surveillance project with deep implications for privacy, security, and equality.
+**Surveillance Project** is a book chapter by [Sunil Abraham](/sunil/), published in *Dissent on Aadhaar: Big Data Meets Big Brother*, edited by Reetika Khera and published by Orient Blackswan in 2018. The chapter critically analyses the Aadhaar programme, arguing that its technological and legal architecture turns a welfare initiative into a mass surveillance project with deep implications for privacy, security, and equality.
 
 This article was originally published in [*Frontline* magazine](/publications/surveillance-project-frontline/) on 30 March 2016.
 

--- a/publications/unlicensed-spectrum-policy.md
+++ b/publications/unlicensed-spectrum-policy.md
@@ -11,7 +11,7 @@ pdf: /publications/files/unlicensed-spectrum-policy.pdf
 created: 2025-11-11
 ---
 
-**Unlicensed Spectrum Policy for Government of India** is a telecom policy paper co-authored by Satya N. Gupta, Sunil Abraham, and Yelena Gyulkhandanyan, published under the CIS Telecom Policy Paper Series (2013).  
+**Unlicensed Spectrum Policy for Government of India** is a telecom policy paper co-authored by Satya N. Gupta, [Sunil Abraham](/sunil/), and Yelena Gyulkhandanyan, published under the CIS Telecom Policy Paper Series (2013).  
 
 The report proposes a roadmap for expanding unlicensed spectrum access in India to support affordable connectivity, local innovation, and inclusive digital growth. Drawing on international experience, it argues that unlicensed spectrum functions as a *public good*, vital for bridging the digital divide and fostering community-based network development.
 

--- a/publications/why-npci-and-facebook-need-urgent-regulatory-attention.md
+++ b/publications/why-npci-and-facebook-need-urgent-regulatory-attention.md
@@ -10,7 +10,7 @@ permalink: /publications/why-npci-and-facebook-need-urgent-regulatory-attention/
 created: 2025-11-15
 ---
 
-**Why NPCI and Facebook Need Urgent Regulatory Attention** is an opinion article by Sunil Abraham, published in *The Economic Times* on 10 June 2018. This article analyses the growing overlap between NPCI's payments infrastructure and large platform actors such as Facebook/WhatsApp, highlighting risks from hyper-centralisation, opacity, data concentration and competition concerns.
+**Why NPCI and Facebook Need Urgent Regulatory Attention** is an opinion article by [Sunil Abraham](/sunil/), published in *The Economic Times* on 10 June 2018. This article analyses the growing overlap between NPCI's payments infrastructure and large platform actors such as Facebook/WhatsApp, highlighting risks from hyper-centralisation, opacity, data concentration and competition concerns.
 
 ## Contents
 


### PR DESCRIPTION
### Motivation
- Ensure lead paragraphs in `publications/*.md` consistently link the author name to the canonical author page for better navigation and attribution. 
- Fix only the first plain-text occurrence of the author name in each lead to avoid over-linking and preserve existing formatting. 
- Limit edits to lead sections so the rest of each publication file remains unchanged.

### Description
- Scanned all Markdown files under `publications/` and identified the lead as the text after YAML front matter and before `## Contents` or the first heading. 
- For files missing `[Sunil Abraham](/sunil/)` in the lead, replaced the first valid standalone plain-text `Sunil Abraham` with `[Sunil Abraham](/sunil/)`, skipping occurrences already linked, emphasized, or part of larger phrases. 
- Applied the targeted replacement to 25 files and committed the changes with the branch commit message `Link Sunil Abraham in publication lead sections`.

### Testing
- Ran the update script via `python - <<'PY' ... PY` to perform scanning and replacements and the script completed successfully. 
- Inspected changes with `git diff -- publications/*.md` and `git status --short` to confirm only the intended single-token replacements across 25 files. 
- Verified link locations with `rg` and `git show` to ensure one replacement per file and successfully committed changes with `git add` and `git commit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3c5c47358832a86f86dfa0f347485)