### PR TITLE
Include CIS navigation box on multiple CIS pages

### DIFF
--- a/cis/annual-report-2008-09.md
+++ b/cis/annual-report-2008-09.md
@@ -384,6 +384,8 @@ The report concluded with an invitation to researchers, practitioners, and organ
   </p>
 </div>
 
+{% include navbox-cis.html %}
+
 <style>
 .table-responsive {
   width: 100%;

--- a/cis/annual-report-2009-10.md
+++ b/cis/annual-report-2009-10.md
@@ -267,6 +267,8 @@ The registered office at the time of the report was No. 194, 2nd 'C' Cross, Doml
   </p>
 </div>
 
+{% include navbox-cis.html %}
+
 <style>
 .table-responsive {
   width: 100%;

--- a/cis/annual-report-2010-11.md
+++ b/cis/annual-report-2010-11.md
@@ -344,6 +344,8 @@ The registered office at the time of the report was No. 194, 2nd 'C' Cross, Doml
   </p>
 </div>
 
+{% include navbox-cis.html %}
+
 <style>
 .table-responsive {
   width: 100%;

--- a/cis/annual-report-2011-12.md
+++ b/cis/annual-report-2011-12.md
@@ -387,6 +387,8 @@ The organisation's primary donors were the Kusuma Trust, Hivos, IDRC, Privacy In
   </p>
 </div>
 
+{% include navbox-cis.html %}
+
 <style>
 .table-responsive {
   width: 100%;

--- a/cis/annual-report-2012-13.md
+++ b/cis/annual-report-2012-13.md
@@ -398,6 +398,8 @@ The organisation's primary donor was the Kusuma Trust. Other funders acknowledge
   </p>
 </div>
 
+{% include navbox-cis.html %}
+
 <style>
 .table-responsive {
   width: 100%;

--- a/cis/concept-note-full-text.md
+++ b/cis/concept-note-full-text.md
@@ -223,3 +223,5 @@ The following is a short list of countries where there are immediate opportuniti
 **Malaysia:** Ex-UNDP colleague is heading Malaysian Administrative Modernization and Management Planning Unit, (MAMPU), Open Source Competency Centre.
 
 **Bangladesh:** UNDP is supporting the Prime Minister's Office with e-Governance implementation. The Chief Advisor of the current care-taker government is Dr. Fakhruddin Ahmed is from civil society and sympathetic to citizen's interests.
+
+{% include navbox-cis.html %}

--- a/cis/concept-note.md
+++ b/cis/concept-note.md
@@ -187,6 +187,8 @@ The concept note identifies several countries and contexts offering immediate op
   </p>
 </div>
 
+{% include navbox-cis.html %}
+
 <style>
 .pdf-container { margin: 1.2rem 0; text-align: center; }
 .pdf-frame {

--- a/cis/index.md
+++ b/cis/index.md
@@ -63,6 +63,8 @@ The Memorandum of Association (MoA) is the founding legal document of CIS, execu
 ## External Link
 - [Official website](https://cis-india.org/)
 
+{% include navbox-cis.html %}
+
 <style>
 .cis-logo-wrap {
   float: right;

--- a/cis/moa-explainer.md
+++ b/cis/moa-explainer.md
@@ -372,6 +372,8 @@ The President is the Chief Functionary of CIS, appointed by the Board of Managem
 
 <p class="explainer-footer">This explainer was prepared by <a href="/">The Sunil Abraham Project</a> for informational purposes only. It is not a legal document. For the authoritative text, see the <a href="/cis/moa/">full Memorandum of Association of CIS</a>.</p>
 
+{% include navbox-cis.html %}
+
 <style>
 .explainer-group {
   display: flex;

--- a/cis/moa.md
+++ b/cis/moa.md
@@ -428,6 +428,8 @@ Every member of the Board of Management including any person(s) authorised by th
 
 - [CIS Memorandum of Association: An Explainer](/cis/moa-explainer/) — a plain-language Q&A guide to this document, prepared by The Sunil Abraham Project
 
+{% include navbox-cis.html %}
+
 <style>
 .cis-logo-wrap {
   float: right;


### PR DESCRIPTION
### Motivation
- Provide consistent site navigation and improve discoverability across Centre for Internet and Society (CIS) pages by adding the shared navbox to article pages.

### Description
- Added the shared include `{% include navbox-cis.html %}` to the end of multiple CIS markdown pages. 
- Files updated include `cis/annual-report-2008-09.md`, `cis/annual-report-2009-10.md`, `cis/annual-report-2010-11.md`, `cis/annual-report-2011-12.md`, `cis/annual-report-2012-13.md`, `cis/concept-note-full-text.md`, `cis/concept-note.md`, `cis/index.md`, `cis/moa-explainer.md`, and `cis/moa.md`.
- No other content or styling changes were made beyond inserting the navbox include and preserving existing page styles.

### Testing
- Ran a local static site build with `jekyll build` and confirmed the build completed without errors. 
- There are no repository unit tests affected by these content include changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f947a19e1c832a81fd55fb1ede473a)