### PR TITLE
fix: add visible keyboard focus outlines

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -101,6 +101,11 @@ a:hover, a:focus {
   color: var(--link-hover);
 }
 
+*:focus-visible {
+  outline: 3px solid var(--link-hover);
+  outline-offset: 3px;
+}
+
 /* =========================================================
    Animations
    ========================================================= */


### PR DESCRIPTION
## Summary

Add a high-visibility focus-visible outline for keyboard navigation.

## Validation

The selector and existing color-token usage were reviewed. git diff --check passed.

Addresses the keyboard-focus portion of #8.